### PR TITLE
Implement collection screen UI with game data integration

### DIFF
--- a/app/(tabs)/collection.tsx
+++ b/app/(tabs)/collection.tsx
@@ -1,9 +1,79 @@
-import { ThemedText } from "@/components/themed-text";
 import { View } from "react-native";
+import Card from "@/components/Card";
+
+type Game = {
+  bgg_id: string;
+  image_path: string;
+  mfg_playtime: string;
+  name: string;
+  genre: string;
+};
+
+// placeholder data
+const games: Game[] = [
+  {
+    bgg_id: "1",
+    image_path:
+      "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTQIF3Z9nTfduAtXffsvWNu5ZC1UjjAErzpag&s",
+    mfg_playtime: "60",
+    name: "Catan",
+    genre: "Strategy",
+  },
+  {
+    bgg_id: "2",
+    image_path:
+      "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQZsz8tahsfdcAqkBL1mDPS3Pgo1HkNlE9jmA&s",
+    mfg_playtime: "30",
+    name: "Ticket to Ride",
+    genre: "Family",
+  },
+  {
+    bgg_id: "3",
+    image_path:
+      "https://cf.geekdo-images.com/aPSHJO0d0XOpQR5X-wJonw__itemrep/img/6oRLPDvy4zz3gOZM6e6NzIk8Seg=/fit-in/246x300/filters:strip_icc()/pic6973671.png",
+    mfg_playtime: "45",
+    name: "Azul",
+    genre: "Abstract",
+  },
+  {
+    bgg_id: "4",
+    image_path:
+      "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTQIF3Z9nTfduAtXffsvWNu5ZC1UjjAErzpag&s",
+    mfg_playtime: "60",
+    name: "Catan",
+    genre: "Strategy",
+  },
+  {
+    bgg_id: "5",
+    image_path:
+      "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQZsz8tahsfdcAqkBL1mDPS3Pgo1HkNlE9jmA&s",
+    mfg_playtime: "30",
+    name: "Ticket to Ride",
+    genre: "Family",
+  },
+  {
+    bgg_id: "6",
+    image_path:
+      "https://cf.geekdo-images.com/aPSHJO0d0XOpQR5X-wJonw__itemrep/img/6oRLPDvy4zz3gOZM6e6NzIk8Seg=/fit-in/246x300/filters:strip_icc()/pic6973671.png",
+    mfg_playtime: "45",
+    name: "Azul",
+    genre: "Abstract",
+  },
+];
+
 export default function CollectionScreen() {
   return (
-    <View>
-      <ThemedText>Collection</ThemedText>
+    <View className="grid grid-cols-2">
+      {games.map((game) => (
+        <Card
+          bgg_id={game.bgg_id}
+          image_path={game.image_path}
+          mfg_playtime={game.mfg_playtime}
+          name={game.name}
+          genre={game.genre}
+          variant="big"
+        />
+      ))}
     </View>
   );
 }

--- a/app/(tabs)/collection.tsx
+++ b/app/(tabs)/collection.tsx
@@ -1,5 +1,7 @@
-import { View } from "react-native";
+import { ScrollView, View, Text, Pressable } from "react-native";
 import Card from "@/components/Card";
+import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
+
 
 type Game = {
   bgg_id: string;
@@ -63,7 +65,18 @@ const games: Game[] = [
 
 export default function CollectionScreen() {
   return (
-    <View className="grid grid-cols-2">
+    <ScrollView className="bg-white">
+      <View className="grid grid-cols-3 my-4">
+        <View className="col-span-2 flex gap-2">
+          <Text className="text-4xl font-bold">My Collection</Text>
+          <Text className="color-slate-600 text-lg">{games.length} Games</Text>
+        </View>
+        <Pressable className="rounded-2xl bg-slate-200 flex flex-row px-6 py-2 gap-1 justify-center items-center max-w-max max-h-max self-center">
+          <MaterialCommunityIcons name="arrow-up-down" size={14} color="grey" />
+          <Text className="color-slate-600">Playtime</Text>
+        </Pressable>
+      </View>
+      <View className="grid grid-cols-2">
       {games.map((game) => (
         <Card
           bgg_id={game.bgg_id}
@@ -71,9 +84,10 @@ export default function CollectionScreen() {
           mfg_playtime={game.mfg_playtime}
           name={game.name}
           genre={game.genre}
-          variant="big"
+          variant="small"
         />
       ))}
-    </View>
+      </View>
+    </ScrollView>
   );
 }

--- a/app/(tabs)/collection.tsx
+++ b/app/(tabs)/collection.tsx
@@ -4,66 +4,6 @@ import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { useAuthContext } from "@/hooks/use-auth-context";
 import { useGamesData } from "@/hooks/use-get-games";
 
-/* type Game = {
-  bgg_id: string;
-  image_path: string;
-  mfg_playtime: string;
-  name: string;
-  genre: string;
-}; */
-
-/* // placeholder data
-const games: Game[] = [
-  {
-    bgg_id: "1",
-    image_path:
-      "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTQIF3Z9nTfduAtXffsvWNu5ZC1UjjAErzpag&s",
-    mfg_playtime: "60",
-    name: "Catan",
-    genre: "Strategy",
-  },
-  {
-    bgg_id: "2",
-    image_path:
-      "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQZsz8tahsfdcAqkBL1mDPS3Pgo1HkNlE9jmA&s",
-    mfg_playtime: "30",
-    name: "Ticket to Ride",
-    genre: "Family",
-  },
-  {
-    bgg_id: "3",
-    image_path:
-      "https://cf.geekdo-images.com/aPSHJO0d0XOpQR5X-wJonw__itemrep/img/6oRLPDvy4zz3gOZM6e6NzIk8Seg=/fit-in/246x300/filters:strip_icc()/pic6973671.png",
-    mfg_playtime: "45",
-    name: "Azul",
-    genre: "Abstract",
-  },
-  {
-    bgg_id: "4",
-    image_path:
-      "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTQIF3Z9nTfduAtXffsvWNu5ZC1UjjAErzpag&s",
-    mfg_playtime: "60",
-    name: "Catan",
-    genre: "Strategy",
-  },
-  {
-    bgg_id: "5",
-    image_path:
-      "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQZsz8tahsfdcAqkBL1mDPS3Pgo1HkNlE9jmA&s",
-    mfg_playtime: "30",
-    name: "Ticket to Ride",
-    genre: "Family",
-  },
-  {
-    bgg_id: "6",
-    image_path:
-      "https://cf.geekdo-images.com/aPSHJO0d0XOpQR5X-wJonw__itemrep/img/6oRLPDvy4zz3gOZM6e6NzIk8Seg=/fit-in/246x300/filters:strip_icc()/pic6973671.png",
-    mfg_playtime: "45",
-    name: "Azul",
-    genre: "Abstract",
-  },
-]; */
-
 export default function CollectionScreen() {
   const { session } = useAuthContext();
   const { games, isLoading, error } = useGamesData(session?.user.id ?? "");
@@ -82,17 +22,17 @@ export default function CollectionScreen() {
       </View>
       {error ? <Text>{error}</Text> : null}
       <View className="grid grid-cols-2">
-      {games.map((game) => (
-        <Card
-          key={game.bgg_id}
-          bgg_id={game.bgg_id}
-          image_path={game.image_path}
-          mfg_playtime={game.mfg_playtime}
-          name={game.name}
-          genre={game.genre}
-          variant="small"
-        />
-      ))}
+        {games.map((game) => (
+          <Card
+            key={game.bgg_id}
+            bgg_id={game.bgg_id}
+            image_path={game.image_path}
+            mfg_playtime={game.mfg_playtime}
+            name={game.name}
+            genre={game.genre}
+            variant="small"
+          />
+        ))}
       </View>
     </ScrollView>
   );

--- a/app/(tabs)/collection.tsx
+++ b/app/(tabs)/collection.tsx
@@ -1,17 +1,18 @@
 import { ScrollView, View, Text, Pressable } from "react-native";
 import Card from "@/components/Card";
-import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+import { useAuthContext } from "@/hooks/use-auth-context";
+import { useGamesData } from "@/hooks/use-get-games";
 
-
-type Game = {
+/* type Game = {
   bgg_id: string;
   image_path: string;
   mfg_playtime: string;
   name: string;
   genre: string;
-};
+}; */
 
-// placeholder data
+/* // placeholder data
 const games: Game[] = [
   {
     bgg_id: "1",
@@ -61,24 +62,29 @@ const games: Game[] = [
     name: "Azul",
     genre: "Abstract",
   },
-];
+]; */
 
 export default function CollectionScreen() {
+  const { session } = useAuthContext();
+  const { games, isLoading, error } = useGamesData(session?.user.id ?? "");
+
   return (
-    <ScrollView className="bg-white">
+    <ScrollView className="bg-white items-center">
       <View className="grid grid-cols-3 my-4">
         <View className="col-span-2 flex gap-2">
           <Text className="text-4xl font-bold">My Collection</Text>
           <Text className="color-slate-600 text-lg">{games.length} Games</Text>
         </View>
-        <Pressable className="rounded-2xl bg-slate-200 flex flex-row px-6 py-2 gap-1 justify-center items-center max-w-max max-h-max self-center">
+        <Pressable className="rounded-2xl bg-slate-200 flex flex-row px-4 py-2 gap-1 justify-center items-center max-w-max max-h-max self-center justify-self-end">
           <MaterialCommunityIcons name="arrow-up-down" size={14} color="grey" />
           <Text className="color-slate-600">Playtime</Text>
         </Pressable>
       </View>
+      {error ? <Text>{error}</Text> : null}
       <View className="grid grid-cols-2">
       {games.map((game) => (
         <Card
+          key={game.bgg_id}
           bgg_id={game.bgg_id}
           image_path={game.image_path}
           mfg_playtime={game.mfg_playtime}

--- a/hooks/use-get-games.ts
+++ b/hooks/use-get-games.ts
@@ -1,0 +1,78 @@
+import { supabase } from "@/utils/supabase";
+import { useCallback, useEffect, useState } from "react";
+
+export type Game = {
+  bgg_id: string;
+  image_path: string;
+  mfg_playtime: string;
+  name: string;
+  genre: string;
+  game_themes?: {
+    themes: {
+      name: string;
+    }[];
+  }[];
+};
+
+export function useGamesData(userId: string) {
+    const [games, setGames] = useState<Game[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState <string | null>(null);
+
+    const getGames = useCallback(async () => {
+        setIsLoading(true);
+        setError(null);
+
+    const { data, error: dbError } = await supabase
+        .from("games")
+        .select(`
+            bgg_id,
+            name,
+            image_path,
+            mfg_playtime,
+            user_collection!inner(
+            user_id
+            ),
+            game_themes!inner(
+                theme_id,
+                themes!inner(
+                id,
+                name
+                )
+            )
+        `)
+        .eq("user_collection.user_id", userId)
+        .order("name", {ascending: true});
+
+    if (dbError) {
+      setError(dbError.message);
+      setGames([]);
+      setIsLoading(false);
+      return;
+    }
+
+    const mappedGames: Game[] = (data ?? []).map((game) => ({
+      bgg_id: String(game.bgg_id),
+      image_path: game.image_path ?? "",
+      mfg_playtime: String(game.mfg_playtime ?? "-"),
+      name: game.name ?? "Unknown game",
+      genre:
+        game.game_themes
+          ?.flatMap((gt) => gt.themes ?? [])
+          .map((theme) => theme.name)
+          .filter(Boolean)
+          .join(", ") || "Board Game",
+    }));
+    setGames(mappedGames);
+    setIsLoading(false);
+  }, [userId]);
+
+
+  useEffect(() => {
+    getGames();
+  }, [getGames]);
+
+  return {games, isLoading, error}
+}
+
+export default useGamesData;


### PR DESCRIPTION
This pull request adds a new custom hook for fetching a user's game collection from the database and refactors the `CollectionScreen` to display this data in a more interactive and visually appealing way. The main focus is on integrating real user data, improving the UI layout, and handling loading and error states.

<img width="444" height="889" alt="image" src="https://github.com/user-attachments/assets/5f038281-214c-41a5-b9cf-50bf050a1391" />

**Data fetching and state management:**

* Introduced a new `useGamesData` hook in `hooks/use-get-games.ts` to fetch games from the Supabase backend based on the current user's ID, map the raw data into a consistent `Game` type, and expose loading and error states.

**UI and display improvements:**

* Refactored `CollectionScreen` in `app/(tabs)/collection.tsx` to use the new `useGamesData` hook, display the actual games in a grid using the `Card` component, and show the total number of games.
* Added a header section with a title, game count, and a sort button (with icon), improving the overall layout and user experience.
* Implemented error handling in the UI to display any data-fetching errors to the user.