### PR TITLE
Refactor Card component to use cva and add size/text props

### DIFF
--- a/app/(tabs)/collection.tsx
+++ b/app/(tabs)/collection.tsx
@@ -9,7 +9,7 @@ export default function CollectionScreen() {
   const { games, isLoading, error } = useGamesData(session?.user.id ?? "");
 
   return (
-    <ScrollView className="bg-white items-center">
+    <ScrollView className="bg-white items-center px-2">
       <View className="grid grid-cols-3 my-4">
         <View className="col-span-2 flex gap-2">
           <Text className="text-4xl font-bold">My Collection</Text>
@@ -30,7 +30,8 @@ export default function CollectionScreen() {
             mfg_playtime={game.mfg_playtime}
             name={game.name}
             genre={game.genre}
-            variant="small"
+            size="tall"
+            text="lg"
           />
         ))}
       </View>

--- a/app/(tabs)/search.tsx
+++ b/app/(tabs)/search.tsx
@@ -47,7 +47,8 @@ export default function SearchScreen() {
             mfg_playtime={game.mfg_playtime}
             name={game.name}
             genre={game.genre}
-            variant="big"
+            size="wide"
+            text="lg"
           />
         ))
       ) : (

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -22,8 +22,8 @@ const cardVariants = cva("", {
       wide: "flex flex-col rounded-3xl bg-white overflow-hidden shadow-md my-4 w-full h-[240px]",
     },
     text: {
-      sm: "my-[0.2] mx-3",
-      lg: "m-3",
+      sm: "my-[0.2] mx-3 truncate",
+      lg: "m-3 truncate",
     },
   },
 });

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -1,8 +1,9 @@
 import Feather from "@expo/vector-icons/Feather";
 import { Link } from "expo-router";
 import { Image, Text, View } from "react-native";
+import { cva, type VariantProps } from "class-variance-authority";
 
-type CardVariant = "big" | "small";
+type CardVariantProps = VariantProps<typeof cardVariants>;
 
 type Props = {
   bgg_id: string;
@@ -10,41 +11,35 @@ type Props = {
   mfg_playtime: string;
   name: string;
   genre: string;
-  variant?: CardVariant;
-};
-const variant = {
-  big: {
-    container:
-      "flex flex-col w-60 h-[240px] rounded-3xl bg-white overflow-hidden shadow-md my-4",
-    text: "m-3",
+} & CardVariantProps;
+
+const cardVariants = cva("", {
+  variants: {
+    size: {
+      sm: "flex flex-col rounded-3xl bg-white overflow-hidden shadow-md my-4 w-48 h-[180px]",
+      lg: "flex flex-col rounded-3xl bg-white overflow-hidden shadow-md my-4 w-60 h-[240px]",
+      tall: "flex flex-col rounded-3xl bg-white overflow-hidden shadow-md my-4 w-11/12 h-[240px] justify-self-center",
+      wide: "flex flex-col rounded-3xl bg-white overflow-hidden shadow-md my-4 w-full h-[240px]",
+    },
+    text: {
+      sm: "my-[0.2] mx-3",
+      lg: "m-3",
+    },
   },
-  small: {
-    container:
-      "flex flex-col w-48 h-[180px] rounded-3xl bg-white overflow-hidden shadow-md my-4",
-    text: "my-[0.2] mx-3",
-  },
-  xl: {
-    container:
-      "flex flex-col w-72 h-[300px] rounded-3xl bg-white overflow-hidden shadow-md my-4",
-    text: "m-4",
-  },
-};
+});
+
 export default function Card({
   bgg_id,
   image_path,
   mfg_playtime,
   name,
   genre,
-  variant = "big",
+  size = "lg",
+  text = "lg",
 }: Props) {
   const imageSource = image_path;
-  const containerClass =
-    variant === "big"
-      ? "flex flex-col w-60 h-[240px] rounded-3xl bg-white overflow-hidden shadow-md my-4"
-      : "flex flex-col w-48 h-[180px] rounded-3xl bg-white overflow-hidden shadow-md my-4";
-  const textClass = variant === "big" ? "m-3" : "my-[0.2] mx-3";
   return (
-    <Link href={`/games/${bgg_id}`} className={containerClass}>
+    <Link href={`/games/${bgg_id}`} className={cardVariants({ size })}>
       <View style={{ width: "100%", height: "70%" }}>
         <Image
           style={{ height: "100%", width: "100%" }}
@@ -57,7 +52,7 @@ export default function Card({
           <Text className="color-slate-500">{mfg_playtime} min</Text>
         </View>
       </View>
-      <View className={textClass}>
+      <View className={cardVariants({ text })}>
         <Text className="font-semibold text-xl">{name}</Text>
         <Text className="color-slate-500">{genre}</Text>
       </View>

--- a/components/CardCarousel.tsx
+++ b/components/CardCarousel.tsx
@@ -50,7 +50,8 @@ export default function CardCarousel({ category, games }: Props) {
             mfg_playtime={item.mfg_playtime}
             name={item.name}
             genre={item.genre}
-            variant={category === "Recommmended for You" ? "big" : "small"}
+            size={category === "Recommmended for You" ? "lg" : "sm"}
+            text={category === "Recommmended for You" ? "lg" : "sm"}
           />
         )}
       ></FlatList>

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@react-navigation/native": "^7.1.8",
         "@supabase/supabase-js": "^2.103.2",
         "babel-preset-expo": "^55.0.17",
+        "class-variance-authority": "^0.7.1",
         "expo": "~54.0.33",
         "expo-constants": "~18.0.13",
         "expo-font": "~14.0.11",
@@ -5194,6 +5195,18 @@
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "license": "MIT"
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -5245,6 +5258,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@react-navigation/native": "^7.1.8",
     "@supabase/supabase-js": "^2.103.2",
     "babel-preset-expo": "^55.0.17",
+    "class-variance-authority": "^0.7.1",
     "expo": "~54.0.33",
     "expo-constants": "~18.0.13",
     "expo-font": "~14.0.11",


### PR DESCRIPTION
This pull request refactors the `Card` component to use the `class-variance-authority` (CVA) library for handling style variants, replacing the previous manual variant logic. It updates all usages of the `Card` component to use the new `size` and `text` props instead of the old `variant` prop, and adds the CVA dependency to the project.

<img width="421" height="647" alt="image" src="https://github.com/user-attachments/assets/4891b807-f1e5-4272-88f7-905533b63373" />

<img width="402" height="581" alt="image" src="https://github.com/user-attachments/assets/f77f431d-7c35-48b3-b72e-f033f5e1ae19" />

<img width="403" height="754" alt="image" src="https://github.com/user-attachments/assets/c26d2ecc-2acb-4ac9-a72d-7d3f7e8daa28" />


Component refactoring and styling improvements:

* Refactored `Card` component in `components/Card.tsx` to use the `class-variance-authority` library for managing style variants, replacing the old `variant` prop with new `size` and `text` props and updating all internal logic to use CVA. [[1]](diffhunk://#diff-e22256f39ac14daca0b6c7400341c609995c98d4924c8c73d0a6b64d8d7006b0R4-R42) [[2]](diffhunk://#diff-e22256f39ac14daca0b6c7400341c609995c98d4924c8c73d0a6b64d8d7006b0L60-R55)
* Updated usages of the `Card` component in `CardCarousel.tsx`, `collection.tsx`, and `search.tsx` to use the new `size` and `text` props instead of `variant`, ensuring consistent styling across the app. [[1]](diffhunk://#diff-0517300be00acf16d586e8e70bfb5d3c8dd9badcccd6cc4b63b5ad0832e5d962L53-R54) [[2]](diffhunk://#diff-ad15efb852b3b0264f9f056665c51c191e7a00e51dabe81f48c7d77f96ebdd46L33-R34) [[3]](diffhunk://#diff-d08f3abc80ef52d1acff6e4438664ab6ccc7f1889bb66dbe438929e6d11b0cf3L50-R51)

Dependency updates:

* Added the `class-variance-authority` package to `package.json` to support the new styling approach.

Minor UI adjustment:

* Added horizontal padding (`px-2`) to the `ScrollView` in `collection.tsx` for improved spacing.