### PR TITLE
refactor: Add sort toggle and empty state to collection

### DIFF
--- a/app/(tabs)/collection.tsx
+++ b/app/(tabs)/collection.tsx
@@ -1,5 +1,6 @@
 import { ScrollView, View, Text, Pressable } from "react-native";
-import { useState } from "react";
+import { useState, useCallback, useEffect } from "react";
+import { useFocusEffect } from "@react-navigation/native";
 import Card from "@/components/Card";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { useAuthContext } from "@/hooks/use-auth-context";
@@ -7,15 +8,22 @@ import { useGamesData } from "@/hooks/use-get-games";
 
 export default function CollectionScreen() {
   const [sortBy, setSortBy] = useState<"name" | "mfg_playtime">("name");
+  const [gameStates, setGamesState] = useState("");
   const { session } = useAuthContext();
 
   const toggleSort = () => {
     setSortBy((prev) => (prev === "name" ? "mfg_playtime" : "name"));
   };
 
-  const { games, isLoading, error } = useGamesData(
+  const { games, isLoading, error, refresh } = useGamesData(
     session?.user.id ?? "",
     sortBy,
+  );
+
+  useFocusEffect(
+    useCallback(() => {
+      refresh();
+    }, [refresh]),
   );
 
   return (

--- a/app/(tabs)/collection.tsx
+++ b/app/(tabs)/collection.tsx
@@ -1,12 +1,22 @@
 import { ScrollView, View, Text, Pressable } from "react-native";
+import { useState } from "react";
 import Card from "@/components/Card";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { useAuthContext } from "@/hooks/use-auth-context";
 import { useGamesData } from "@/hooks/use-get-games";
 
 export default function CollectionScreen() {
+  const [sortBy, setSortBy] = useState<"name" | "mfg_playtime">("name");
   const { session } = useAuthContext();
-  const { games, isLoading, error } = useGamesData(session?.user.id ?? "");
+
+  const toggleSort = () => {
+    setSortBy((prev) => (prev === "name" ? "mfg_playtime" : "name"));
+  };
+
+  const { games, isLoading, error } = useGamesData(
+    session?.user.id ?? "",
+    sortBy,
+  );
 
   return (
     <ScrollView className="bg-white items-center px-2">
@@ -15,26 +25,35 @@ export default function CollectionScreen() {
           <Text className="text-4xl font-bold">My Collection</Text>
           <Text className="color-slate-600 text-lg">{games.length} Games</Text>
         </View>
-        <Pressable className="rounded-2xl bg-slate-200 flex flex-row px-4 py-2 gap-1 justify-center items-center max-w-max max-h-max self-center justify-self-end">
+        <Pressable
+          className="rounded-2xl bg-slate-200 flex flex-row px-4 py-2 gap-1 justify-center items-center max-w-max max-h-max self-center justify-self-end"
+          onPress={toggleSort}
+        >
           <MaterialCommunityIcons name="arrow-up-down" size={14} color="grey" />
-          <Text className="color-slate-600">Playtime</Text>
+          <Text className="color-slate-600">
+            {sortBy === "name" ? "Name" : "Playtime"}
+          </Text>
         </Pressable>
       </View>
       {error ? <Text>{error}</Text> : null}
-      <View className="grid grid-cols-2">
-        {games.map((game) => (
-          <Card
-            key={game.bgg_id}
-            bgg_id={game.bgg_id}
-            image_path={game.image_path}
-            mfg_playtime={game.mfg_playtime}
-            name={game.name}
-            genre={game.genre}
-            size="tall"
-            text="lg"
-          />
-        ))}
-      </View>
+      {games.length > 0 ? (
+        <View className="grid grid-cols-2">
+          {games.map((game) => (
+            <Card
+              key={game.bgg_id}
+              bgg_id={game.bgg_id}
+              image_path={game.image_path}
+              mfg_playtime={game.mfg_playtime}
+              name={game.name}
+              genre={game.genre}
+              size="tall"
+              text="lg"
+            />
+          ))}
+        </View>
+      ) : (
+        <Text className="color-slate-600 text-2xl">No games in collection</Text>
+      )}
     </ScrollView>
   );
 }

--- a/hooks/use-get-games.ts
+++ b/hooks/use-get-games.ts
@@ -73,7 +73,7 @@ export function useGamesData(userId: string, sort: string) {
     getGames();
   }, [getGames]);
 
-  return { games, isLoading, error };
+  return { games, isLoading, error, refresh: getGames };
 }
 
 export default useGamesData;

--- a/hooks/use-get-games.ts
+++ b/hooks/use-get-games.ts
@@ -14,18 +14,19 @@ export type Game = {
   }[];
 };
 
-export function useGamesData(userId: string) {
-    const [games, setGames] = useState<Game[]>([]);
-    const [isLoading, setIsLoading] = useState(true);
-    const [error, setError] = useState <string | null>(null);
+export function useGamesData(userId: string, sort: string) {
+  const [games, setGames] = useState<Game[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-    const getGames = useCallback(async () => {
-        setIsLoading(true);
-        setError(null);
+  const getGames = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
 
     const { data, error: dbError } = await supabase
-        .from("games")
-        .select(`
+      .from("games")
+      .select(
+        `
             bgg_id,
             name,
             image_path,
@@ -40,9 +41,10 @@ export function useGamesData(userId: string) {
                 name
                 )
             )
-        `)
-        .eq("user_collection.user_id", userId)
-        .order("name", {ascending: true});
+        `,
+      )
+      .eq("user_collection.user_id", userId)
+      .order(sort, { ascending: true });
 
     if (dbError) {
       setError(dbError.message);
@@ -65,14 +67,13 @@ export function useGamesData(userId: string) {
     }));
     setGames(mappedGames);
     setIsLoading(false);
-  }, [userId]);
-
+  }, [userId, sort]);
 
   useEffect(() => {
     getGames();
   }, [getGames]);
 
-  return {games, isLoading, error}
+  return { games, isLoading, error };
 }
 
 export default useGamesData;


### PR DESCRIPTION
Add a sort toggle to CollectionScreen that switches between sorting by name and manufacturer playtime, update the button label and pass the selected sort key into useGamesData. Update hooks/use-get-games.ts to accept a sort parameter, apply it to the Supabase .order(...) call, and include sort in the hook's dependency array. Also render a fallback "No games in collection" message when the games list is empty and clean up minor typing/formatting issues.