### PR TITLE
refactor: Add collection, quickPlay, and recommended fetches

### DIFF
--- a/app/(tabs)/collection.tsx
+++ b/app/(tabs)/collection.tsx
@@ -1,5 +1,5 @@
 import { ScrollView, View, Text, Pressable } from "react-native";
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback } from "react";
 import { useFocusEffect } from "@react-navigation/native";
 import Card from "@/components/Card";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
@@ -8,14 +8,13 @@ import { useGamesData } from "@/hooks/use-get-games";
 
 export default function CollectionScreen() {
   const [sortBy, setSortBy] = useState<"name" | "mfg_playtime">("name");
-  const [gameStates, setGamesState] = useState("");
   const { session } = useAuthContext();
 
   const toggleSort = () => {
     setSortBy((prev) => (prev === "name" ? "mfg_playtime" : "name"));
   };
 
-  const { games, isLoading, error, refresh } = useGamesData(
+  const { collection, isLoading, error, refresh } = useGamesData(
     session?.user.id ?? "",
     sortBy,
   );
@@ -31,7 +30,9 @@ export default function CollectionScreen() {
       <View className="grid grid-cols-3 my-4">
         <View className="col-span-2 flex gap-2">
           <Text className="text-4xl font-bold">My Collection</Text>
-          <Text className="color-slate-600 text-lg">{games.length} Games</Text>
+          <Text className="color-slate-600 text-lg">
+            {collection.length} Games
+          </Text>
         </View>
         <Pressable
           className="rounded-2xl bg-slate-200 flex flex-row px-4 py-2 gap-1 justify-center items-center max-w-max max-h-max self-center justify-self-end"
@@ -43,10 +44,13 @@ export default function CollectionScreen() {
           </Text>
         </Pressable>
       </View>
-      {error ? <Text>{error}</Text> : null}
-      {games.length > 0 ? (
+      {isLoading ? (
+        <Text className="color-slate-600 text-2xl">Getting Collection...</Text>
+      ) : null}
+      {error ? <Text className="text-red-600">{error}</Text> : null}
+      {collection.length > 0 ? (
         <View className="grid grid-cols-2">
-          {games.map((game) => (
+          {collection.map((game) => (
             <Card
               key={game.bgg_id}
               bgg_id={game.bgg_id}

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,52 +1,23 @@
 import CardCarousel from "@/components/CardCarousel";
 import { ScrollView, Text, View } from "react-native";
-
-type Game = {
-  bgg_id: string;
-  image_path: string;
-  mfg_playtime: string;
-  name: string;
-  genre: string;
-};
-
-// placeholder data
-const games: Game[] = [
-  {
-    bgg_id: "1",
-    image_path:
-      "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTQIF3Z9nTfduAtXffsvWNu5ZC1UjjAErzpag&s",
-    mfg_playtime: "60",
-    name: "Catan",
-    genre: "Strategy",
-  },
-  {
-    bgg_id: "2",
-    image_path:
-      "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQZsz8tahsfdcAqkBL1mDPS3Pgo1HkNlE9jmA&s",
-    mfg_playtime: "30",
-    name: "Ticket to Ride",
-    genre: "Family",
-  },
-  {
-    bgg_id: "3",
-    image_path:
-      "https://cf.geekdo-images.com/aPSHJO0d0XOpQR5X-wJonw__itemrep/img/6oRLPDvy4zz3gOZM6e6NzIk8Seg=/fit-in/246x300/filters:strip_icc()/pic6973671.png",
-    mfg_playtime: "45",
-    name: "Azul",
-    genre: "Abstract",
-  },
-];
+import { useAuthContext } from "@/hooks/use-auth-context";
+import { useGamesData } from "@/hooks/use-get-games";
 
 export default function HomeScreen() {
+  const { session } = useAuthContext();
+  const { collection, recommendedGames, quickPlay, isLoading, error, refresh } =
+    useGamesData(session?.user.id ?? "", "name");
+
   return (
     <ScrollView className="bg-white px-4">
       <View className="my-4">
         <Text className="text-4xl font-bold ">Welcome back</Text>
         <Text className="my-2 color-slate-600 text-xl">Ready to play?</Text>
       </View>
-      <CardCarousel category="Quick Play" games={games} />
-      <CardCarousel category="Recommmended for You" games={games} />
-      <CardCarousel category="Your Collection" games={games} />
+      {error ? <Text className="text-red-600">{error}</Text> : null}
+      <CardCarousel category="Quick Play" games={quickPlay} />
+      <CardCarousel category="Recommmended for You" games={recommendedGames} />
+      <CardCarousel category="Your Collection" games={collection} />
     </ScrollView>
   );
 }

--- a/components/CardCarousel.tsx
+++ b/components/CardCarousel.tsx
@@ -31,7 +31,7 @@ export default function CardCarousel({ category, games }: Props) {
         )}
         {category == "Quick Play" ? (
           <Text className="color-slate-400 flex items-center">
-            Under 30 min
+            Under 45 min
           </Text>
         ) : (
           <></>

--- a/hooks/use-get-games.ts
+++ b/hooks/use-get-games.ts
@@ -15,11 +15,135 @@ export type Game = {
 };
 
 export function useGamesData(userId: string, sort: string) {
-  const [games, setGames] = useState<Game[]>([]);
+  const [collection, setCollection] = useState<Game[]>([]);
+  const [recommendedGames, setRecommendedGames] = useState<Game[]>([]);
+  const [quickPlay, setQuickPlay] = useState<Game[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const getGames = useCallback(async () => {
+  //SQL fetch to get quickplay
+  const getQuickPlay = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    const { data, error: dbError } = await supabase
+      .from("games")
+      .select(
+        `
+            bgg_id,
+            name,
+            image_path,
+            mfg_playtime,
+            user_collection!inner(
+            user_id
+            ),
+            game_themes!inner(
+                theme_id,
+                themes!inner(
+                id,
+                name
+                )
+            )
+        `,
+      )
+      .eq("user_collection.user_id", userId)
+      .lt("mfg_playtime", 45)
+      .order("mfg_playtime", { ascending: true });
+
+    if (dbError) {
+      setError(dbError.message);
+      setQuickPlay([]);
+      setIsLoading(false);
+      return;
+    }
+
+    const mappedGames: Game[] = (data ?? []).map((game) => ({
+      bgg_id: String(game.bgg_id),
+      image_path: game.image_path ?? "",
+      mfg_playtime: String(game.mfg_playtime ?? "-"),
+      name: game.name ?? "Unknown game",
+      genre:
+        game.game_themes
+          ?.flatMap((gt) => gt.themes ?? [])
+          .map((theme) => theme.name)
+          .filter(Boolean)
+          .join(", ") || "Board Game",
+    }));
+    setQuickPlay(mappedGames);
+    setIsLoading(false);
+  }, [userId]);
+
+  //SQL fetch to get recommended games
+  const getRecommended = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    const { data: collectionRows, error: collectionError } = await supabase
+      .from("user_collection")
+      .select("game_id")
+      .eq("user_id", userId);
+
+    if (collectionError) {
+      setError(collectionError.message);
+      setRecommendedGames([]);
+      setIsLoading(false);
+      return;
+    }
+
+    const collectedIds = (collectionRows ?? []).map((row) => row.game_id);
+
+    let query = supabase
+      .from("games")
+      .select(
+        `
+      bgg_id,
+      name,
+      image_path,
+      mfg_playtime,
+      game_themes(
+        theme_id,
+        themes(
+          id,
+          name
+        )
+      )
+    `,
+      )
+      .order("rank_boardgame", { ascending: true })
+      .limit(20);
+
+    if (collectedIds.length > 0) {
+      query = query.not("bgg_id", "in", `(${collectedIds.join(",")})`);
+    }
+
+    const { data, error: dbError } = await query;
+
+    if (dbError) {
+      setError(dbError.message);
+      setRecommendedGames([]);
+      setIsLoading(false);
+      return;
+    }
+
+    const mappedGames: Game[] = (data ?? []).map((game) => ({
+      bgg_id: String(game.bgg_id),
+      image_path: game.image_path ?? "",
+      mfg_playtime: String(game.mfg_playtime ?? "-"),
+      name: game.name ?? "Unknown game",
+      genre:
+        game.game_themes
+          ?.flatMap((gt) => gt.themes ?? [])
+          .map((theme) => theme.name)
+          .filter(Boolean)
+          .join(", ") || "Board Game",
+    }));
+
+    setRecommendedGames(mappedGames);
+    setIsLoading(false);
+  }, [userId]);
+
+  //SQL fetch to get users collection
+  const getCollection = useCallback(async () => {
     setIsLoading(true);
     setError(null);
 
@@ -48,7 +172,7 @@ export function useGamesData(userId: string, sort: string) {
 
     if (dbError) {
       setError(dbError.message);
-      setGames([]);
+      setCollection([]);
       setIsLoading(false);
       return;
     }
@@ -65,15 +189,24 @@ export function useGamesData(userId: string, sort: string) {
           .filter(Boolean)
           .join(", ") || "Board Game",
     }));
-    setGames(mappedGames);
+    setCollection(mappedGames);
     setIsLoading(false);
   }, [userId, sort]);
 
   useEffect(() => {
-    getGames();
-  }, [getGames]);
+    getCollection();
+    getRecommended();
+    getQuickPlay();
+  }, [getCollection, getRecommended, getQuickPlay]);
 
-  return { games, isLoading, error, refresh: getGames };
+  return {
+    collection,
+    recommendedGames,
+    quickPlay,
+    isLoading,
+    error,
+    refresh: getCollection,
+  };
 }
 
 export default useGamesData;


### PR DESCRIPTION
Refactor use-get-games to provide three separate lists (collection, recommendedGames, quickPlay) with dedicated Supabase queries, mapping, and error/loading handling. Call getCollection, getRecommended, and getQuickPlay on mount and return the new datasets (refresh still points to getCollection). Update CollectionScreen to use collection (remove unused state/import), show loading and styled error states, and render collection items. Update HomeScreen to remove placeholder data, use useAuthContext and useGamesData, and feed CardCarousel components with quickPlay, recommendedGames, and collection.