### PR TITLE
refactor: Adjust collection layout and card styles

### DIFF
--- a/app/(tabs)/collection.tsx
+++ b/app/(tabs)/collection.tsx
@@ -5,9 +5,6 @@ import Card from "@/components/Card";
 import { useAuthContext } from "@/hooks/use-auth-context";
 import { useGamesData } from "@/hooks/use-get-games";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
-import { useFocusEffect } from "@react-navigation/native";
-import { useCallback, useState } from "react";
-import { Pressable, ScrollView, Text, View } from "react-native";
 
 export default function CollectionScreen() {
   const [sortBy, setSortBy] = useState<"name" | "mfg_playtime">("name");
@@ -30,10 +27,10 @@ export default function CollectionScreen() {
 
   return (
     <ScrollView
-      className="mt-16 px-2 "
+      className="mt-16 px-2"
       contentContainerStyle={{ alignItems: "center" }}
     >
-      <View className=" my-4 ">
+      <View className=" my-4 flex flex-row w-full justify-between">
         <View className=" flex gap-2">
           <Text className="text-4xl font-bold">My Collection</Text>
           <Text className="color-slate-600 text-lg">
@@ -41,10 +38,15 @@ export default function CollectionScreen() {
           </Text>
         </View>
         <Pressable
-          className="rounded-2xl bg-slate-200 flex flex-row px-4 py-2 gap-1 justify-center justify-center max-w-max max-h-max self-center justify-self-end"
+          className="rounded-2xl bg-slate-200 flex flex-row px-4 py-2 gap-1 justify-center justify-items-center max-w-max max-h-max self-center justify-self-end"
           onPress={toggleSort}
         >
-          <MaterialCommunityIcons name="arrow-up-down" size={14} color="grey" />
+          <MaterialCommunityIcons
+            name="arrow-up-down"
+            size={14}
+            color="grey"
+            className="self-center"
+          />
           <Text className="color-slate-600">
             {sortBy === "name" ? "Name" : "Playtime"}
           </Text>
@@ -53,10 +55,10 @@ export default function CollectionScreen() {
       {isLoading ? (
         <Text className="color-slate-600 text-2xl">Getting Collection...</Text>
       ) : null}
-      {error ? <Text>{error}</Text> : null}
-      {games.length > 0 ? (
+      {error ? <Text className="text-red-600">{error}</Text> : null}
+      {collection.length > 0 ? (
         <View className="w-full flex-row flex-wrap">
-          {games.map((game) => (
+          {collection.map((game) => (
             <View key={game.bgg_id} className="w-1/2 p-2">
               <Card
                 bgg_id={game.bgg_id}

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -18,7 +18,7 @@ const cardVariants = cva("", {
     size: {
       sm: "flex flex-col rounded-3xl bg-white overflow-hidden shadow-md my-4 w-48 h-[180px]",
       lg: "flex flex-col rounded-3xl bg-white overflow-hidden shadow-md my-4 w-60 h-[240px]",
-      tall: "flex flex-col rounded-3xl bg-white overflow-hidden shadow-md my-4 w-11/12 h-[240px] justify-self-center",
+      tall: "flex flex-col rounded-3xl bg-white overflow-hidden shadow-md my-4 w-full h-[240px] justify-self-center",
       wide: "flex flex-col rounded-3xl bg-white overflow-hidden shadow-md my-4 w-full h-[240px]",
     },
     text: {


### PR DESCRIPTION
Refine the Collection screen layout and styling: tighten spacing, add row/justify-between to the header, adjust the sort button classes and center the icon, and show errors in red. Switch rendering to use the collection array (collection.length / collection.map) instead of games. Clean up some imports. Update Card.tall variant to use full width (w-full) instead of w-11/12 for consistent card sizing.

<img width="424" height="708" alt="image" src="https://github.com/user-attachments/assets/379af0ca-ed75-4d97-896f-cb5259cb95f3" />
